### PR TITLE
Filter spoiler

### DIFF
--- a/common_res/js_forum.js
+++ b/common_res/js_forum.js
@@ -378,7 +378,39 @@ o_topic.parentNode.insertBefore(tmp,o_topic.nextSibling);
 if(topicMisc._BIT1&134217728)
 	commonui.loadThreadInfoLoadReply(o_topic.parentNode,(quote_from ? quote_from : tid))
 
+	// Done with topic title, proceed to filter spoiler.
+	// Skip topic with any color or additional class besides 'topic'
+	try {
+		if (o_topic.classList.length == 1 || o_topic.classList.length == 2 && o_topic.classList[1] == 'AgDUGNM') {
+			var spoilerRe = /.*¾çÍ¸.*/;
+			if (spoilerRe.test(o_topic.textContent)) {
+				var tmpHint = document.createElement('span');
+				tmpHint.className = 'silver';
+				tmpHint.innerText = '[¾çÍ¸] '
 
+				o_topic.style['transition'] = 'opacity 2s';
+				o_topic.style['-webkit-transition'] = 'opacity 2s';
+				o_topic.style['-moz-transition'] = 'opacity 2s';
+				o_topic.style['-o-transition'] = 'opacity 2s';
+				o_topic.style.opacity = 0;
+				o_topic.parentNode.insertBefore(tmpHint, o_topic);
+				o_topic.addEventListener('mouseover', function (e) {
+					this.style.opacity = 1;
+					if (tmpHint) {
+						o_topic.parentNode.removeChild(tmpHint);
+					}
+				});
+				o_topic.addEventListener('mouseout', function (e) {
+					this.style.opacity = 0;
+					if (tmpHint) {
+						o_topic.parentNode.insertBefore(tmpHint, o_topic);
+					}
+				});
+			}
+		}
+	} catch (error) {
+		// update your browser!
+	}
 //o_replies.style.display=o_ptime.style.display=o_rtime.style.display='none'
 
 if (admin&1)


### PR DESCRIPTION
检索到剧透两个字，就会把文字透明化，并且追加剧透标签（前端only）。鼠标悬浮后在2秒内解除效果（并且移除追加的标签）。